### PR TITLE
Introduce note search functionality

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -34,8 +34,6 @@ function activate(context) {
         return;
       }
 
-      vscode.window.showInformationMessage(`I will create note - ${title}`);
-
       let newFilePath = `${CONFIG.notes_root}/${title}.${CONFIG.notes_format}`;
 
       fs.open(newFilePath, "w", async error => {
@@ -55,7 +53,36 @@ function activate(context) {
     }
   );
 
+  let searchNote = vscode.commands.registerCommand(
+    "gkeep.searchNotes",
+    async () => {
+      const fileTuples = await vscode.workspace.fs.readDirectory(
+        vscode.Uri.file(CONFIG.notes_root)
+      );
+
+      const noteFiles = fileTuples
+        .filter(([_, type]) => type === vscode.FileType.File)
+        .map(([name, _]) => name)
+        .filter(name => name.endsWith(CONFIG.notes_format));
+
+      const selectedFileName = await vscode.window.showQuickPick(noteFiles, {
+        placeHolder: "Enter note title...",
+        canPickMany: false
+      });
+
+      if (!selectedFileName) {
+        return;
+      }
+
+      const doc = await vscode.workspace.openTextDocument(
+        vscode.Uri.file(`${CONFIG.notes_root}/${selectedFileName}`)
+      );
+      vscode.window.showTextDocument(doc);
+    }
+  );
+
   context.subscriptions.push(createNoteCommand);
+  context.subscriptions.push(searchNote);
 }
 exports.activate = activate;
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
       {
         "command": "gkeep.createNote",
         "title": "GKeep: Create Note"
+      },
+      {
+        "command": "gkeep.searchNotes",
+        "title": "GKeep: Search Note"
       }
     ]
   },


### PR DESCRIPTION
Task: https://github.com/kanevk/gkeep-on-vscode/projects/1#card-32882919

## Search functionality

### Background

Gkeep-on-vscode will be VScode extension. A core feature is to have a way to search through the "Notes root" directory and open the relevant notes.

### AIM

Search note functionality

1. Find note command
2. Search input + to all matches
3. Choose a note and opened it by clicking enter